### PR TITLE
[SB-564] O atributo token será enviado somente se != vazio

### DIFF
--- a/src/ResponseJson.php
+++ b/src/ResponseJson.php
@@ -26,9 +26,12 @@ class ResponseJson
         $response = [
             'data' => $data,
             'profiler' => $profiler,
-            'token' => $token,
             'requestId' => $requestId,
         ];
+
+        if (!empty($token)) {
+            $response['token'] = $token;
+        }
 
         if (!empty($message)) {
             $response['message'] = $message;


### PR DESCRIPTION
No pacote de Json Response, o atributo/campo deve ser exibido somente quando enviado, caso contrário, o mesmo não será adicionado na listagem do response